### PR TITLE
Make Vulkan non-mandatory

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -52,9 +52,12 @@ target_link_libraries( BurekTechX
         AdmUtils
         BtxCommon
         ElegyRhi
-        Vulkan-Headers
         ftxui::component
         ${SDL2_LIBRARIES} )
+
+if ( NVRHI_WITH_VULKAN )
+        target_link_libraries( BurekTechX Vulkan-Headers )
+endif()
 
 if ( NOT DEFINED BTX_BIN_DIRECTORY )
         set( BTX_BIN_DIRECTORY ${BTX_ROOT}/bin )

--- a/engine/Engine.Render.cpp
+++ b/engine/Engine.Render.cpp
@@ -11,7 +11,10 @@
 #include "pluginsystem/PluginSystem.hpp"
 
 #include "elegy-rhi/DeviceManager.hpp"
+
+#if USE_VK
 #include <vulkan/vulkan.h>
+#endif
 
 #include "Engine.hpp"
 
@@ -24,6 +27,7 @@ namespace Utilities
 		return *(reinterpret_cast<const nvrhi::app::WindowSurfaceData*>(&engineWindowSurface));
 	}
 
+#if USE_VK
 	// This is truly not necessary, could just use SDL_Vulkan_GetInstanceExtensions, 
 	// but I'm doing this for the sake of GoldSRC Half-Life support, cuz' there's an ancient version of SDL2 in there
 	static void FillRequiredVulkanExtensions( Vector<String>& extensions )
@@ -44,6 +48,7 @@ namespace Utilities
 #endif
 #endif
 	}
+#endif
 
 	static void SynchroniseVideoFormat( IWindow* window, nvrhi::Format targetFormat )
 	{
@@ -74,7 +79,11 @@ namespace Utilities
 			return nvrhi::GraphicsAPI::D3D11;
 		}
 
+#if USE_VK
 		return nvrhi::GraphicsAPI::VULKAN;
+#else
+		return nvrhi::GraphicsAPI::D3D12;
+#endif
 	}
 }
 

--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -278,6 +278,8 @@ bool Engine::InitialiseApplications()
 		console.Error( applicationPluginErrorString.c_str() );
 		return false;
 	}
+
+	return true;
 }
 
 // ============================


### PR DESCRIPTION
In one source file, the engine includes Vulkan headers, thus assuming the user has Vulkan SDK installed, and causing compiler errors if that's not satisfied.

This PR fixes that, and adds another minor fix to `Engine::InitialiseApplications` to always return a value.